### PR TITLE
Support Basic TypeScript Features

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -4,6 +4,7 @@ pub enum Language {
     Python,
     Ruby,
     Cpp,
+    TypeScript,
     Other(String),
 }
 
@@ -14,6 +15,7 @@ impl Language {
             Self::Python => "python",
             Self::Ruby => "ruby",
             Self::Cpp => "cpp",
+            Self::TypeScript => "typescript",
             Self::Other(language) => language.as_str(),
         }
     }
@@ -27,6 +29,7 @@ impl Language {
             "cpp" => Self::Cpp,
             "h" => Self::Cpp,
             "hpp" => Self::Cpp,
+            "ts" => Self::TypeScript,
             other_extension => Self::Other(other_extension.to_string()),
         }
     }
@@ -38,6 +41,7 @@ impl Language {
             Language::Python => "module",
             Language::Ruby => "program",
             Language::Cpp => "translation_unit",
+            Language::TypeScript => "program",
             _ => "",
         }
     }
@@ -48,6 +52,7 @@ impl Language {
             Language::Python => "null",
             Language::Ruby => "null",
             Language::Cpp => "null",
+            Language::TypeScript => "decorator",
             _ => "",
         }
     }
@@ -58,6 +63,7 @@ impl Language {
             Language::Python => "comment",
             Language::Ruby => "comment",
             Language::Cpp => "comment",
+            Language::TypeScript => "comment",
             _ => "",
         }
     }
@@ -113,6 +119,14 @@ impl Language {
                 "function_definition",
                 "class_specifier",
             ],
+            Language::TypeScript => vec![
+                "function_declaration",
+                "class_declaration",
+                "method_definition",
+                "export_statement",
+                "interface_declaration",
+                "expression_statement", // namespace
+            ],
             _ => vec![],
         }
     }
@@ -123,6 +137,11 @@ impl Language {
             Language::Python => vec!["class_definition"],
             Language::Ruby => vec!["class", "module"],
             Language::Cpp => vec!["namespace_definition", "class_specifier"],
+            Language::TypeScript => vec![
+                "class_declaration", 
+                "expression_statement", 
+                "internal_module",
+            ],
             _ => vec![],
         }
     }
@@ -135,6 +154,7 @@ impl From<&str> for Language {
             "python" => Self::Python,
             "ruby" => Self::Ruby,
             "cpp" => Self::Cpp,
+            "typescript" => Self::TypeScript,
             other_language => Self::Other(other_language.to_string()),
         }
     }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -5,6 +5,7 @@ pub enum CommentToken {
     Python,
     Ruby,
     Cpp,
+    TypeScript,
     Other,
 }
 
@@ -15,6 +16,7 @@ impl CommentToken {
             Language::Python => CommentToken::Python,
             Language::Ruby => CommentToken::Ruby,
             Language::Cpp => CommentToken::Cpp,
+            Language::TypeScript => CommentToken::TypeScript,
             _ => CommentToken::Other,
         }
     }
@@ -25,6 +27,7 @@ impl CommentToken {
             CommentToken::Python => "# [TODO]",
             CommentToken::Ruby => "# [TODO]",
             CommentToken::Cpp => "/// [TODO]",
+            CommentToken::TypeScript => "// [TODO]",
             CommentToken::Other => "// [TODO]",
         }
     }

--- a/src/tree_sitter_extended.rs
+++ b/src/tree_sitter_extended.rs
@@ -122,7 +122,17 @@ impl ResolveSymbol for Node<'_> {
             }
         }
 
-        let identifier_node = node.unwrap();
+        if self.kind() == "export_statement" {
+            if let Some(child) = self.child_by_field_name("declaration") {
+                node = child.child_by_field_name("name");
+            }
+        }
+
+        if self.kind() == "method_definition" {
+            node = self.child_by_field_name("name");
+        }
+
+        let identifier_node = node.expect("identifier_node is None");
 
         let from = identifier_node.start_position().column;
         let row = identifier_node.end_position().row;

--- a/tests/integration_test/analyze_command_test.rs
+++ b/tests/integration_test/analyze_command_test.rs
@@ -12,3 +12,6 @@ mod cpp_test;
 
 #[cfg(test)]
 mod c_test;
+
+#[cfg(test)]
+mod ts_test;

--- a/tests/integration_test/analyze_command_test/ts_test.rs
+++ b/tests/integration_test/analyze_command_test/ts_test.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod typescript_case_test;

--- a/tests/integration_test/analyze_command_test/ts_test/typescript_case_test.rs
+++ b/tests/integration_test/analyze_command_test/ts_test/typescript_case_test.rs
@@ -1,0 +1,171 @@
+use crate::integration_test::assert_analyzed_source_code;
+use indoc::indoc;
+
+#[test]
+fn test_typescript_functions() {
+    let source_code = indoc! {r#"
+    function parseBindingIdentifier(privateIdentifierDiagnosticMessage?: DiagnosticMessage) {
+        return createIdentifier(isBindingIdentifier(), /*diagnosticMessage*/ undefined, privateIdentifierDiagnosticMessage);
+    }
+
+    export function parseIdentifier(diagnosticMessage?: DiagnosticMessage, privateIdentifierDiagnosticMessage?: DiagnosticMessage): Identifier {
+        return createIdentifier(isIdentifier(), diagnosticMessage, privateIdentifierDiagnosticMessage);
+    }
+
+    export function parseIdentifierName(diagnosticMessage?: DiagnosticMessage): Identifier {
+        return createIdentifier(tokenIsIdentifierOrKeyword(token()), diagnosticMessage);
+    }"#};
+
+    let expected = indoc! {r#"
+    // [TODO] parseBindingIdentifier
+    function parseBindingIdentifier(privateIdentifierDiagnosticMessage?: DiagnosticMessage) {
+        return createIdentifier(isBindingIdentifier(), /*diagnosticMessage*/ undefined, privateIdentifierDiagnosticMessage);
+    }
+
+    // [TODO] parseIdentifier
+    export function parseIdentifier(diagnosticMessage?: DiagnosticMessage, privateIdentifierDiagnosticMessage?: DiagnosticMessage): Identifier {
+        return createIdentifier(isIdentifier(), diagnosticMessage, privateIdentifierDiagnosticMessage);
+    }
+
+    // [TODO] parseIdentifierName
+    export function parseIdentifierName(diagnosticMessage?: DiagnosticMessage): Identifier {
+        return createIdentifier(tokenIsIdentifierOrKeyword(token()), diagnosticMessage);
+    }"#};
+
+    assert_analyzed_source_code(source_code, expected, "typescript")
+}
+
+#[test]
+fn test_multiple_interfaces() {
+    let source_code = indoc! {r#"
+    export interface EmitOutput {
+        outputFiles: OutputFile[];
+        emitSkipped: boolean;
+        /** @internal */ diagnostics: readonly Diagnostic[];
+    }
+    
+    interface OutputFile {
+        name: string;
+        writeByteOrderMark: boolean;
+        text: string;
+        /** @internal */ data?: WriteFileCallbackData;
+    }"#};
+
+    let expected = indoc! {r#"
+    // [TODO] EmitOutput
+    export interface EmitOutput {
+        outputFiles: OutputFile[];
+        emitSkipped: boolean;
+        /** @internal */ diagnostics: readonly Diagnostic[];
+    }
+    
+    // [TODO] OutputFile
+    interface OutputFile {
+        name: string;
+        writeByteOrderMark: boolean;
+        text: string;
+        /** @internal */ data?: WriteFileCallbackData;
+    }"#};
+
+    assert_analyzed_source_code(source_code, expected, "typescript")
+}
+
+#[test]
+#[ignore = "Not supported yet"]
+fn test_arrow_function() {
+    let source_code = indoc! {r#"
+    export const foo = <T extends {}>(myObject: T) => myObject.toString();"#};
+    
+    let expected = indoc! {r#"
+    // [TODO] foo
+    export const foo = <T extends {}>(myObject: T) => myObject.toString();"#};
+
+    assert_analyzed_source_code(source_code, expected, "typescript")
+}
+
+#[test]
+// TODO: support export class
+fn test_class_declaration_without_export_symbol() {
+    let source_code = indoc! {r#"
+    class Person {
+        private name: string;
+
+        public constructor(name: string) {
+            this.name = name;
+        }
+
+        public getName(): string {
+            return this.name;
+        }
+    }"#};
+
+    let expected = indoc! {r#"
+    // [TODO] Person
+    class Person {
+        private name: string;
+
+        // [TODO] Person > constructor
+        public constructor(name: string) {
+            this.name = name;
+        }
+
+        // [TODO] Person > getName
+        public getName(): string {
+            return this.name;
+        }
+    }"#};
+
+    assert_analyzed_source_code(source_code, expected, "typescript")
+}
+
+#[test]
+fn test_class_extend_with_implementation() {
+    let source_code = indoc! {r#"
+    export interface Pingable {
+        ping(): void;
+    }
+
+    class Sonar implements Pingable {
+        ping() {
+            console.log("ping!");
+        }
+    }"#};
+
+    let expected = indoc! {r#"
+    // [TODO] Pingable
+    export interface Pingable {
+        ping(): void;
+    }
+
+    // [TODO] Sonar
+    class Sonar implements Pingable {
+        // [TODO] Sonar > ping
+        ping() {
+            console.log("ping!");
+        }
+    }"#};
+
+    assert_analyzed_source_code(source_code, expected, "typescript")
+}
+
+#[test]
+#[ignore = "Not supported yet"]
+fn test_namespace() {
+    let source_code = indoc! {r#"
+    namespace Animal {
+        function animalsHaveMuscles() {
+            return foo;
+        }
+    }"#};
+
+    let expected = indoc! {r#"
+    // [TODO] Animal
+    namespace Animal {
+        // [TODO] Animal > animalsHaveMuscles
+        function animalsHaveMuscles() {
+            return foo;
+        }
+    }"#};
+
+    assert_analyzed_source_code(source_code, expected, "typescript")
+}


### PR DESCRIPTION
## :star2: What does this PR do?

Add language support for TypeScript. This PR only handles function, class (without `export`) and interfaces. also added TypeScript code examples.

Arrow functions and classes (with export) should be supported later.

